### PR TITLE
16: adding in checks for transient dummy vm.

### DIFF
--- a/src/sevcore.h
+++ b/src/sevcore.h
@@ -114,6 +114,7 @@ private:
     bool valid_qemu(virDomainPtr dom);
     bool valid_libvirt(virConnectPtr con);
     bool valid_ovmf(virDomainPtr dom, bool sev_enabled, char *sev_temp_dir);
+    bool dom_state_up(virDomainPtr dom);
     bool dom_state_down(virDomainPtr dom);
     virDomainPtr start_new_domain(virConnectPtr con, std::string name,
                                   bool sev_enable, struct sev_dom_details dom_details,


### PR DESCRIPTION
Adding in a more thorough check for transient VM's. If the OVMF shell vm
is found to be running after waiting an acceptable alotted time,
virDomainDestory command is given to destroy the transient VM. This
should.

Also added in some timing logic to help reduce the margin of error for
the OVMF shell vm starting and shutting down properly.

Signed-off-by: Larry Dewey <ldewey@suse.com>