### PR TITLE
Fix Issue 22

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -742,9 +742,9 @@ int Command::generate_launch_blob(uint32_t policy)
         // Write the unencrypted TK (TIK and TEK) to a tmp file so it can be
         // read in during package_secret
         std::string tmp_tk_file = m_output_folder + GUEST_TK_FILENAME;
-        sev::write_file(tmp_tk_file, &m_tk, sizeof(m_tk));
 
         cmd_ret = build_session_buffer(&session_data_buf, policy, godh_key_pair, &pdh);
+        sev::write_file(tmp_tk_file, &m_tk, sizeof(m_tk));
         if (cmd_ret == STATUS_SUCCESS) {
             if (m_verbose_flag) {
                 printf("Guest Policy (input): %08x\n", policy);


### PR DESCRIPTION
In the current code, the file is written before the keys are created,
meaning that the tmp_tk.bin file contains rubbish and everything that
relies on reading it back in doesn't work.

Fix by moving the write of the file until after the keys have been
generated in build_session_buffer()

Signed-off-by: James Bottomley <James.Bottomley@HansenPartnership.com>