### PR TITLE
Fix Issue 24

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -817,7 +817,7 @@ int Command::package_secret(void)
 
         // Read in the unencrypted TK (TIK and TEK) created in build_session_buffer
         std::string tmp_tk_file = m_output_folder + GUEST_TK_FILENAME;
-        if (sev::read_file(tmp_tk_file, &m_tk, sizeof(m_tk) != sizeof(m_tk))) {
+        if (sev::read_file(tmp_tk_file, &m_tk, sizeof(m_tk)) != sizeof(m_tk)) {
             printf("Error reading in %s\n", tmp_tk_file.c_str());
             break;
         }


### PR DESCRIPTION
The expression has the third argument as

sizeof(m_tk) != sizeof(m_tk)

which always returns zero meaning the code does a zero length read of
tmp_tk.bin and thus m_tk ends up containing stack junk which causes
sev-tool to build an incorrect secret package.

I think the intention is for the third argument to be sizeof(m_tk) and
then for the return to be checked against this value.

Signed-off-by: James Bottomley <James.Bottomley@HansenPartnership.com>