### PR TITLE
deps-install.sh: Install automake package

### DIFF
--- a/deps-install.sh
+++ b/deps-install.sh
@@ -91,7 +91,7 @@ find_distribution_details()
 	else
 		debug $LINENO ":" "Regular expression could not match: \n" "${OS_RELEASE}"
 		echo "Distribution not recognized. Please manually install "\
-			"libelf libraries, libvirt-devel, make, zip, gcc, g++, git, wget, autoconf, and libssl-dev." >&2
+			"libelf libraries, libvirt-devel, make, zip, gcc, g++, git, wget, automake, autoconf, and libssl-dev." >&2
 		exit 1
 	fi
 
@@ -132,6 +132,7 @@ check_dependencies()
 		[ "$(rpm -q 'wget' 2>&1 | grep 'not installed')" != "" ]           ||
 		[ "$(rpm -q ${LIBVIRT_NAME} 2>&1 | grep 'not installed')" != "" ]  ||
 		[ "$(rpm -q ${UUID_NAME} 2>&1 | grep 'not installed')" != "" ]     ||
+		[ "$(rpm -q 'automake' 2>&1 | grep 'not installed')" != "" ]       ||
 		[ "$(rpm -q ${AUTO_CONF} 2>&1 | grep 'not installed')" != "" ]     ||
 		[ "$(rpm -q ${SSL_DEV} 2>&1 | grep 'not installed')" != "" ]       ||
 		[ "$(rpm -q ${GCC_CPP} 2>&1 | grep 'not installed')" != "" ]
@@ -154,6 +155,7 @@ check_dependencies()
 		[ "$(dpkg -l 'wget' 2>&1 | grep 'no packages')" != "" ]           ||
 		[ "$(dpkg -l ${LIBVIRT_NAME} 2>&1 | grep 'no packages')" != "" ]  ||
 		[ "$(dpkg -l ${UUID_NAME} 2>&1 | grep 'no packages')" != "" ]     ||
+		[ "$(dpkg -l 'automake' 2>&1 | grep 'no packages')" != "" ]       ||
 		[ "$(dpkg -l ${AUTO_CONF} 2>&1 | grep 'no packages')" != "" ]     ||
 		[ "$(dpkg -l ${SSL_DEV} 2>&1 | grep 'no packages')" != "" ]       ||
 		[ "$(dpkg -l ${GCC_CPP} 2>&1 | grep 'no packages')" != "" ]
@@ -303,8 +305,8 @@ main()
 			[yY]*)
 				debug $LINENO ":" "User responded with YES."
 				debug $LINENO ":" "Running Command: \"sudo ${INSTALLER} install -y git make gcc "\
-					"zip wget ${LIBVIRT_NAME} ${UUID_NAME} ${AUTO_CONF} ${SSL_DEV} ${GCC_CPP}\""
-				sudo ${INSTALLER} install -y git make gcc zip wget ${UUID_NAME} ${LIBVIRT_NAME} ${AUTO_CONF} ${SSL_DEV} ${GCC_CPP}
+					"zip wget ${LIBVIRT_NAME} ${UUID_NAME} automake ${AUTO_CONF} ${SSL_DEV} ${GCC_CPP}\""
+				sudo ${INSTALLER} install -y git make gcc zip wget ${UUID_NAME} ${LIBVIRT_NAME} automake ${AUTO_CONF} ${SSL_DEV} ${GCC_CPP}
 				;;
 			*)
 				debug $LINENO ":" "User responded with no."


### PR DESCRIPTION
On RHEL 8, installing autoconf doesn't install automake, and then the
build fails:

    $ autoreconf -if && ./configure && make
    Can't exec "aclocal": No such file or directory at /usr/share/autoconf/Autom4te/FileUtils.pm line 326.
    autoreconf: failed to run aclocal: No such file or directory

Add automake to the list of packages which are checked and installed (it
has the same name in both Debian and Red Hat).