### PR TITLE
hotfix: Fixing c_str error.

### DIFF
--- a/src/sevcore_linux.cpp
+++ b/src/sevcore_linux.cpp
@@ -179,9 +179,9 @@ int sev::get_ask_ark_pem(const std::string output_folder, const std::string cert
         }
 
         // Create the required SEV assets directory if it doesn't exist.
-        if (stat(SEV_DEFAULT_DIR.c_str(), &file_details) == -1) {
+        if (stat(SEV_DEFAULT_DIR, &file_details) == -1) {
             if (errno == ENOENT) {
-                if (mkdir(SEV_DEFAULT_DIR.c_str(), 0775) != -1) {
+                if (mkdir(SEV_DEFAULT_DIR, 0775) != -1) {
                     printf("Info: Created missing directory: %s\n", SEV_DEFAULT_DIR);
                 } else {
                     fprintf(stderr, "Error: Unable to create required directory: %s\n", SEV_DEFAULT_DIR);


### PR DESCRIPTION
Fixing an error when attempting to use c_str() on a macro defined
C-style string.

Signed-off-by: Larry Dewey <larry@SCS-L10-lardewe.amd.com>