### PR TITLE
48: Using SNP_PLATFORM_STATUS for TCB Version

### DIFF
--- a/lib/psp-sev.h
+++ b/lib/psp-sev.h
@@ -20,14 +20,20 @@
  */
 enum {
     SEV_FACTORY_RESET = 0,
-    SEV_PLATFORM_STATUS,
-    SEV_PEK_GEN,
-    SEV_PEK_CSR,
-    SEV_PDH_GEN,
-    SEV_PDH_CERT_EXPORT,
-    SEV_PEK_CERT_IMPORT,
+    SEV_PLATFORM_STATUS,   // 0x1
+    SEV_PEK_GEN,           // 0x2
+    SEV_PEK_CSR,           // 0x3
+    SEV_PDH_GEN,           // 0x4
+    SEV_PDH_CERT_EXPORT,   // 0x5
+    SEV_PEK_CERT_IMPORT,   // 0x6
     SEV_GET_ID,    /* This command is deprecated, use SEV_GET_ID2 */
-    SEV_GET_ID2,
+    SEV_GET_ID2,           // 0x8
+
+    // Subject to change. Current info based on the sev-snp-part2 branch AMDESE/Linux fork.
+    // https://github.com/AMDESE/linux/blob/sev-snp-part2-v6/include/uapi/linux/psp-sev.h
+    SEV_SNP_PLATFORM_STATUS,   // 0x9
+    SEV_SNP_SET_EXT_CONFIG,    // 0xA
+    SEV_SNP_GET_EXT_CONFIG,    // 0xB
 
     SEV_MAX,
 };

--- a/readme.md
+++ b/readme.md
@@ -468,7 +468,6 @@ This command calls the get_id command and passes that ID into the AMD KDS server
          ```
 22. export_cert_chain_vcek
      - This command exports all of the certs (VCEK, ASK, ARK) as .pem files and zips them up so that the Platform Owner can send them to the Guest Owner to allow the Guest Owner to validate the vcek cert chain and the SNP guest message's Attestation report from SNP_GUEST_REQUEST. The tool gets the VCEK and ASK_ARK certificates from the AMD KDS server.
-     - Required input args: TCBVersion returned from SNPPlatformStatus as a decimal string
      - Optional input args: --ofolder [folder_path]
          - This allows the user to specify the folder where the tool will export all of the certificates to and the zip folder in
      - Files read in: none
@@ -477,8 +476,7 @@ This command calls the get_id command and passes that ID into the AMD KDS server
      -  Platform/Guest Owner: Platform Owner
      - Example
          ```sh
-         $ sudo ./sevtool --ofolder ./certs --export_cert_chain_vcek [tcb_version]
-         $ sudo ./sevtool --ofolder ./certs --export_cert_chain_vcek 0000000000000163
+         $ sudo ./sevtool --ofolder ./certs --export_cert_chain_vcek
          ```
 
 ## Running tests

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -573,7 +573,7 @@ int Command::export_cert_chain(void)
     return (int)cmd_ret;
 }
 
-int Command::generate_all_certs_vcek(const std::string tcb_version)
+int Command::generate_all_certs_vcek(void)
 {
     int cmd_ret = -1;
 
@@ -586,7 +586,7 @@ int Command::generate_all_certs_vcek(const std::string tcb_version)
     do {
         // Generate the vcek from the AMD KDS server
         cmd_ret = m_sev_device->generate_vcek_ask(m_output_folder, vcek_der_file,
-                                                  vcek_pem_file, tcb_version);
+                                                  vcek_pem_file);
         if (cmd_ret != STATUS_SUCCESS)
             break;
 
@@ -602,7 +602,7 @@ int Command::generate_all_certs_vcek(const std::string tcb_version)
     return (int)cmd_ret;
 }
 
-int Command::export_cert_chain_vcek(const std::string tcb_version)
+int Command::export_cert_chain_vcek(void)
 {
     int cmd_ret = -1;
     std::string zip_name = CERTS_VCEK_ZIP_FILENAME;
@@ -620,7 +620,7 @@ int Command::export_cert_chain_vcek(const std::string tcb_version)
             break;
         }
 
-        cmd_ret = generate_all_certs_vcek(tcb_version);
+        cmd_ret = generate_all_certs_vcek();
         if (cmd_ret != STATUS_SUCCESS)
             break;
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -100,7 +100,7 @@ private:
 
     int calculate_measurement(measurement_t *user_data, hmac_sha_256 *final_meas);
     int generate_all_certs(void);
-    int generate_all_certs_vcek(const std::string tcb_version);
+    int generate_all_certs_vcek(void);
     int import_all_certs(sev_cert *pdh, sev_cert *pek, sev_cert *oca,
                          sev_cert *cek, amd_cert *ask, amd_cert *ark);
     bool kdf(uint8_t *key_out, size_t key_out_length, const uint8_t *key_in,
@@ -150,7 +150,7 @@ public:
     int generate_cek_ask(void);
     int get_ask_ark(void);
     int export_cert_chain(void);
-    int export_cert_chain_vcek(const std::string tcb_version);
+    int export_cert_chain_vcek(void);
     int calc_measurement(measurement_t *user_data);
     int validate_cert_chain(void);
     int generate_launch_blob(uint32_t policy);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,8 +67,6 @@ const char help_array[] =  "The following commands are supported:\n" \
                     "  validate_guest_report\n" \
                     "  validate_cert_chain_vcek\n" \
                     "  export_cert_chain_vcek\n" \
-                    "      Input params:\n" \
-                    "          std::string tcb_version\n" \
                     ;
 
 /* Flag set by '--verbose' */
@@ -94,7 +92,7 @@ static struct option long_options[] =
     {"set_externally_owned",     required_argument, 0, 'l'},
     {"generate_cek_ask",         no_argument,       0, 'm'},
     {"export_cert_chain",        no_argument,       0, 'p'},
-    {"export_cert_chain_vcek",   required_argument, 0, 'q'},
+    {"export_cert_chain_vcek",   no_argument,       0, 'q'},
     {"sign_pek_csr",             required_argument, 0, 's'},
     /* Guest Owner commands */
     {"get_ask_ark",              no_argument,       0, 'n'},
@@ -240,15 +238,8 @@ int main(int argc, char **argv)
                 break;
             }
             case 'q': {         // EXPORT_CERT_CHAIN_VCEK
-                optind--;   // Can't use option_index because it doesn't account for '-' flags
-                if (argc - optind != 1) {
-                    printf("Error: Expecting exactly 1 arg for export_cert_chain_vcek\n");
-                    return false;
-                }
-
-                const std::string tcb_version = argv[optind++];
                 Command cmd(output_folder, verbose_flag);
-                cmd_ret = cmd.export_cert_chain_vcek(tcb_version);
+                cmd_ret = cmd.export_cert_chain_vcek();
                 break;
             }
            case 's': {         // SIGN_PEK_CSR

--- a/src/sevcore.h
+++ b/src/sevcore.h
@@ -17,6 +17,8 @@
 #ifndef SEVCORE_H
 #define SEVCORE_H
 
+#include "rmp.h"
+#include "sevapi.h"
 #include "sevcert.h"
 #include <cstddef>
 #include <cstring>
@@ -136,8 +138,9 @@ public:
                          const std::string cert_file);
     int generate_vcek_ask(const std::string output_folder,
                           const std::string vcek_der_file,
-                          const std::string vcek_pem_file,
-                          const std::string tcb_version);
+                          const std::string vcek_pem_file);
+    int request_platform_status(snp_platform_status_buffer &plat_status);
+    void request_tcb_data(snp_tcb_version &tcb_data);
 };
 
 #endif /* SEVCORE_H */

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -844,7 +844,6 @@ bool Tests::test_export_cert_chain_vcek(void)
 {
     bool ret = false;
     Command cmd(m_output_folder, m_verbose_flag);
-    const std::string tcb_version = "0000000000000163";
 
     do {
         if (sev::get_device_type() != PSP_DEVICE_TYPE_MILAN) {
@@ -855,7 +854,7 @@ bool Tests::test_export_cert_chain_vcek(void)
 
         printf("*Starting export_cert_chain_vcek tests\n");
 
-        if (cmd.export_cert_chain_vcek(tcb_version) != STATUS_SUCCESS)
+        if (cmd.export_cert_chain_vcek() != STATUS_SUCCESS)
             break;
 
         ret = true;


### PR DESCRIPTION
This changes the approach used for finding the TCB Version for the
certificate chain requests. Instead of taking a commandline parameter,
this will now use the TCB content provided by the Platform Status
retrieved from the PSP.

Addresses #48

Signed-off-by: Larry Dewey <larry.dewey@amd.com>