### PR TITLE
Fix `grep` pattern to find correct CPU family

### DIFF
--- a/src/sevcore_linux.cpp
+++ b/src/sevcore_linux.cpp
@@ -545,7 +545,7 @@ int SEVDevice::sys_info()
     printf("Firmware Version: %s\n", build_info.c_str());
 
     sev::get_family_model(&family, &model);
-    printf("Platform Family %02x, Model %02x\n", family, model);
+    printf("Platform Family 0x%02x, Model 0x%02x\n", family, model);
 
     printf("-------------------------------------------------------------\n\n");
 

--- a/src/sevcore_linux.cpp
+++ b/src/sevcore_linux.cpp
@@ -37,9 +37,9 @@ void sev::get_family_model(uint32_t *family, uint32_t *model)
     std::string fam_str = "";
     std::string model_str = "";
 
-    cmd = "lscpu | grep -E \"CPU family:\" | awk {'print $3'}";
+    cmd = "lscpu | grep -E \"^CPU family:\" | awk {'print $3'}";
     sev::execute_system_command(cmd, &fam_str);
-    cmd = "lscpu | grep -E \"Model:\" | awk {'print $2'}";
+    cmd = "lscpu | grep -E \"^Model:\" | awk {'print $2'}";
     sev::execute_system_command(cmd, &model_str);
 
     *family = std::stoi(fam_str, NULL, 10);


### PR DESCRIPTION
With the recent version of `lscpu` (from `util-linux` 2.38), `sudo ./sev-tools --sys_info` fails with the following error:
```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoi
[1]    1221889 IOT instruction  sudo ./sevtool --sys_info
```
This is because the output also includes another field `BIOS Model name:`" that can match [the existing `grep` pattern](https://github.com/AMDESE/sev-tool/blob/f0f7a830313c74f5eb52dd8bde92724962b560fc/src/sevcore_linux.cpp#L40). Below shows an example of such output (`lscpu` running as root):
<pre>
# sudo lscpu 
Architecture:            x86_64
  CPU op-mode(s):        32-bit, 64-bit
  Address sizes:         43 bits physical, 48 bits virtual
  Byte Order:            Little Endian
CPU(s):                  56
  On-line CPU(s) list:   0-55
Vendor ID:               AuthenticAMD
  BIOS Vendor ID:        Advanced Micro Devices, Inc.
  Model name:            AMD EPYC 7453 28-Core Processor
    BIOS Model name:     AMD EPYC 7453 28-Core Processor                 Unknown CPU @ 2.7GHz
    <b>BIOS CPU family</b>:     107
    <b>CPU family</b>:          25
    Model:               1
    Thread(s) per core:  2
    Core(s) per socket:  28
    Socket(s):           1
    Stepping:            1
    Frequency boost:     enabled
    CPU(s) scaling MHz:  92%
    CPU max MHz:         3488.5249
    CPU min MHz:         1500.0000
    BogoMIPS:            5500.16
............ # omitted for brevity
</pre>
`BIOS CPU family` precedes `CPU family` so `grep` didn't find the correct line and `stoi` failed as a result.

Add a caret symbol in the `grep` pattern so it always matches from the start of the line. The same is done for the model number, just in case.

Also added `0x` to indicate hex number in the output of Platform Family to avoid any confusion.
