### PR TITLE
SSL: Upgrade autoconf openssl api check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,8 +11,21 @@ dnl in this dir (build-aux)
 AC_CONFIG_AUX_DIR(build-aux)
 
 dnl Check that OpenSSL is >= 1.1.0 by looking for version specific APIs
-AC_SEARCH_LIBS(EVP_PKEY_base_id, crypto, [],
-			   [AC_MSG_ERROR([Incompatible version of OpenSSL found])])
+dnl OpenSSL 1.1.1.x uses EVP_PKEY_base_id
+dnl OpenSSL 3.0.x renamed to EVP_PKEY_get_base_id
+AC_SEARCH_LIBS(
+	EVP_PKEY_base_id,
+	crypto,
+	[],
+	[AC_SEARCH_LIBS(
+		EVP_PKEY_get_base_id,
+		crypto,
+		[],
+		[AC_MSG_ERROR(
+			[Incompatible version of OpenSSL found]
+		)]
+	)]
+)
 
 dnl Commented out because we are currently using sev-tool/lib/psp-sev.h
 dnl


### PR DESCRIPTION
Adding in additional checks which guarantee that OpenSSL is greater than
version 1.1.0.x, as it is incompatible with sev-tool. Previously the
check for 1.1.1.x was looking for the API EVP_PKEY_base_id in the crypto
library. In the latest version 3.0.x of OpenSSL, that API was re-named
to EVP_PKEY_get_base_id. As both are acceptable version, we will check
for each of them.

Additional changes will need to be made before the next release to
address the deprecation warnings.

- Updated autoconf check for OpenSSL 3.0.x compatibility.

Addresses #71

Signed-off-by: Larry Dewey <larry.dewey@amd.com>