### PR TITLE
Fix build deps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Updated: 2021-09-17
 2. Install git, make, gcc, g++, and openssl dependencies
    - In most cases, you can run `deps-install.sh`.
      ```sh
-     $ sh deps-install.sh
+     $ bash deps-install.sh
      ```
    - If you would like to manually install dependencies, and are running Debian, Ubuntu
      ```sh
@@ -74,7 +74,7 @@ Updated: 2021-09-17
    - To run the build script
      ```sh
      $ cd sev-tool
-     $ autoreconf -vif && ./configure && make
+     $ autoreconf -vif && ./configure && make && cp src/sevtool .
      ```
 
 ## How to Run the SEV-Tool

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Updated: 2021-09-17
      ```sh
      $ cd sev-tool
      $ git pull
-     $ autoreconf -vif && ./configure && make
+     $ autoreconf -vif && ./configure && make && mv src/sevtool .
      ```
 2. Run the tool with the help flag (-h or --help):
      ```sh


### PR DESCRIPTION
Running the deps installation script with sh yields the following error
``` bash
$ sh deps-install.sh
deps-install.sh: 197: Bad substitution
```
If we simply run it with bash, then we fix this issue. This occurred on Ubuntu 20.04.5 LTS focal.

``` bash
$ bash deps-install.sh
```

In addition, the sevtool binary is generated within the src folder. 
Since the readme doesn't mention its location, I considered it would be better to move from src to repo root folder.
```bash
$ cd sev-tool
$ git pull
$ autoreconf -vif && ./configure && make && mv src/sevtool .
```

[]'s