### PR TITLE
Fix outdated ASK_ARK_PATH_SITE

### DIFF
--- a/src/sevcore.h
+++ b/src/sevcore.h
@@ -30,7 +30,7 @@
 const std::string DEFAULT_SEV_DEVICE     = "/dev/sev";
 
 #define AMD_SEV_DEVELOPER_SITE    "https://developer.amd.com/sev/"
-#define ASK_ARK_PATH_SITE         "https://developer.amd.com/wp-content/resources/"
+#define ASK_ARK_PATH_SITE         "https://download.amd.com/developer/eula/sev/"
 
 const std::string ASK_ARK_NAPLES_FILE    = "ask_ark_naples.cert";
 const std::string ASK_ARK_ROME_FILE      = "ask_ark_rome.cert";


### PR DESCRIPTION
https://developer.amd.com/wp-content/resources does not function anymore. The certificates now live on https://download.amd.com/developer/eula/sev.