### PR TITLE
84: Patching returned TCB Value

### DIFF
--- a/src/sevcore_linux.cpp
+++ b/src/sevcore_linux.cpp
@@ -791,7 +791,7 @@ void SEVDevice::request_tcb_data(snp_tcb_version &tcb_data) {
             std::strerror(ioctl_return)
         );
     } else {
-        tcb_data.val = plat_status.tcb_version;
+        tcb_data.val = plat_status.reported_tcb;
     }
 }
 


### PR DESCRIPTION
This patches the `request_tcb_data` method whcih was returning the `tcb_version` from the `snp_platform_status_buffer` structure. When it should have been returning the `reported_tcb` field from the structure.

Fixes: #84