### PR TITLE
Ensure sev-tool works regardless of system language settings

### DIFF
--- a/src/sevcore_linux.cpp
+++ b/src/sevcore_linux.cpp
@@ -37,9 +37,9 @@ void sev::get_family_model(uint32_t *family, uint32_t *model)
     std::string fam_str = "";
     std::string model_str = "";
 
-    cmd = "lscpu | grep -E \"^CPU family:\" | awk {'print $3'}";
+    cmd = "LANG=C lscpu | grep -E \"^CPU family:\" | awk {'print $3'}";
     sev::execute_system_command(cmd, &fam_str);
-    cmd = "lscpu | grep -E \"^Model:\" | awk {'print $2'}";
+    cmd = "LANG=C lscpu | grep -E \"^Model:\" | awk {'print $2'}";
     sev::execute_system_command(cmd, &model_str);
 
     *family = std::stoi(fam_str, NULL, 10);
@@ -527,7 +527,7 @@ int SEVDevice::sys_info()
     sev::execute_system_command(cmd, &output);
     cmd = "echo -n 'BIOS Release Date: '; dmidecode -s bios-release-date";
     sev::execute_system_command(cmd, &output);
-    cmd = "echo -n 'SMT/Multi-Threading Status Per Socket: \n'; lscpu | grep -E \"^CPU\\(s\\):|Thread\\(s\\) per core|Core\\(s\\) per socket|Socket\\(s\\)\"";
+    cmd = "echo -n 'SMT/Multi-Threading Status Per Socket: \n'; LANG=C lscpu | grep -E \"^CPU\\(s\\):|Thread\\(s\\) per core|Core\\(s\\) per socket|Socket\\(s\\)\"";
     sev::execute_system_command(cmd, &output);
     cmd = "echo -n 'Processor Frequency (all sockets): \n'; dmidecode -s processor-frequency";
     sev::execute_system_command(cmd, &output);


### PR DESCRIPTION
This PR proposes to change the way to execute `lscpu` command inside the code.
In the current implementation, there are some code which parse the output of `lscpu` but it fails in the Japanese environment because the output of `lscpu` is Japanese.
As a result, `export_cert_chain` and `export_cert_chain_vcek` fail and it's difficult to guess the cause from the error message.

To ensure those commands work regardless of language environment, this PR proposes to prepend `LANG=C` to all the `lscpu` command in the code.